### PR TITLE
server/editorServices: Fix 'Cannot read property 'enable' of undefined'

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1525,6 +1525,8 @@ namespace ts.server {
             }
 
             project.setProjectErrors(configFileErrors);
+            // Fix for https://github.com/angular/angular/issues/20552
+            project.setTypeAcquisition(projectOptions.typeAcquisition);
             const filesToAdd = projectOptions.files.concat(project.getExternalFiles());
             this.addFilesToNonInferredProjectAndUpdateGraph(project, filesToAdd, fileNamePropertyReader, projectOptions.typeAcquisition);
             this.configuredProjects.set(project.canonicalConfigFilePath, project);


### PR DESCRIPTION
This commit fixes issue https://github.com/angular/angular/issues/20552
caused by `typeAcquisition` being null when the Angular plugin tries to
retrieve external files during startup.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
