### PR TITLE
server/project: Add external files to root files map

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -898,6 +898,7 @@ namespace ts.server {
                 inserted => {
                     const scriptInfo = this.projectService.getOrCreateScriptInfoNotOpenedByClient(inserted, this.currentDirectory, this.directoryStructureHost);
                     scriptInfo.attachToProject(this);
+                    this.rootFilesMap.set(scriptInfo.path, scriptInfo);
                 },
                 removed => this.detachScriptInfoFromProject(removed),
                 compareStringsCaseSensitive


### PR DESCRIPTION
This commit fixes a bug whereby semantic errors are not shown on
external files because external files are not considered part of project
root files.
This issue was discovered while investigating an issue where
semantic errors are not shown in external Angular templates.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'help wanted' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
